### PR TITLE
Add BlackRock New Grad

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Support [Nick Scialli](https://github.com/nas5w) directly on his repo! [Intervie
 | [Airbnb]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Amazon]() | Seattle, WA, US | 🔒 **[Not Open Yet]** 🔒 |
 | [Apple]() | Cupertino, CA | 🔒 **[Not Open Yet]** 🔒 |
+| [Atlassian]() | Sydney, Australia | 🔒 **[Not Open Yet]** 🔒 |
+| [BlackRock](https://careers.blackrock.com/early-careers/americas/?2023-2024#tab-id-13) | Atlanta, GA; San Francisco, CA; New York, NY | ✅ [SWE, PM, Quant](https://blackrock.tal.net/vx/lang-en-GB/mobile-0/brand-3/xf-232eb66ac89a/candidate/so/pm/1/pl/1/opp/7893-Analyst-Program-Americas/en-GB) - [See Description PDF](https://static.wcn.co.uk/company/blackrock/JobDescription23/BlackRock_2023-2024_Software_Engineering_Job_Description.pdf) ✅|
 | [Cisco]() | San Jose, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Dropbox]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Facebook]() | Menlo Park, CA | 🔒 **[Not Open Yet]** 🔒 |
@@ -53,12 +55,10 @@ Support [Nick Scialli](https://github.com/nas5w) directly on his repo! [Intervie
 | [Netflix]() | Los Gatos, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Nvidia]() | Santa Clara, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Oracle]() | Redwood City, CA | 🔒 **[Not Open Yet]** 🔒 |
-| [Atlassian]() | Sydney, Australia | 🔒 **[Not Open Yet]** 🔒 |
 | [PayPal]() | San Jose, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Pinterest]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Reddit]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Salesforce]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
-| [Uber]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Slack]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Snap]() | Los Angeles, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Spotify]() | Stockholm, Sweden | 🔒 **[Not Open Yet]** 🔒 |
@@ -67,11 +67,11 @@ Support [Nick Scialli](https://github.com/nas5w) directly on his repo! [Intervie
 | [TikTok]() | Los Angeles, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Twitch]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Twitter]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
+| [Uber]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [VMware]() | Palo Alto, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Yelp]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Zillow]() | Seattle, WA | 🔒 **[Not Open Yet]** 🔒 |
 | [Zoom]() | San Jose, CA | 🔒 **[Not Open Yet]** 🔒 |
-| [BlackRock](https://careers.blackrock.com/early-careers/americas/?2023-2024#tab-id-13) | Atlanta, GA; San Francisco, CA; New York, NY | ✅ [SWE, PM, Quant](https://blackrock.tal.net/vx/lang-en-GB/mobile-0/brand-3/xf-232eb66ac89a/candidate/so/pm/1/pl/1/opp/7893-Analyst-Program-Americas/en-GB) - [See Description PDF](https://static.wcn.co.uk/company/blackrock/JobDescription23/BlackRock_2023-2024_Software_Engineering_Job_Description.pdf) ✅|
 
 -END OF LIST-
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Support [Nick Scialli](https://github.com/nas5w) directly on his repo! [Intervie
 | [Airbnb]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Amazon]() | Seattle, WA, US | 🔒 **[Not Open Yet]** 🔒 |
 | [Apple]() | Cupertino, CA | 🔒 **[Not Open Yet]** 🔒 |
-| [BlackRock]() | New York, NY | 🔒 **[Not Open Yet]** 🔒 |
 | [Cisco]() | San Jose, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Dropbox]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Facebook]() | Menlo Park, CA | 🔒 **[Not Open Yet]** 🔒 |
@@ -72,6 +71,7 @@ Support [Nick Scialli](https://github.com/nas5w) directly on his repo! [Intervie
 | [Yelp]() | San Francisco, CA | 🔒 **[Not Open Yet]** 🔒 |
 | [Zillow]() | Seattle, WA | 🔒 **[Not Open Yet]** 🔒 |
 | [Zoom]() | San Jose, CA | 🔒 **[Not Open Yet]** 🔒 |
+| [BlackRock](https://careers.blackrock.com/early-careers/americas/?2023-2024#tab-id-13) | Atlanta, GA; San Francisco, CA; New York, NY | ✅ [SWE, PM, Quant](https://blackrock.tal.net/vx/lang-en-GB/mobile-0/brand-3/xf-232eb66ac89a/candidate/so/pm/1/pl/1/opp/7893-Analyst-Program-Americas/en-GB) - [See Description PDF](https://static.wcn.co.uk/company/blackrock/JobDescription23/BlackRock_2023-2024_Software_Engineering_Job_Description.pdf) ✅|
 
 -END OF LIST-
 


### PR DESCRIPTION
Add postings for Technology > Software Engineering.

> BlackRock has the rest of the roles **Quant**, **PM**, under Software Engr according to the [PDF](https://static.wcn.co.uk/company/blackrock/JobDescription23/BlackRock_2023-2024_Software_Engineering_Job_Description.pdf)

Feel free to correct if wrong.