### PR TITLE
Add Immuta Citizenship/Visa Requirements clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The icons next to roles in the table below signify the following:
 | Name         | Location     | Roles                | Citizenship/Visa Requirements | Date Added <br> mm/dd/yyyy |
 | ------------ | ------------ | -------------------- | ----------------------------- | --------------------------- |
 | [Alchemy](https://boards.greenhouse.io/alchemy) | - San Francisco, CA <br> - New York, NY | ✅ [Software Engineer (New Grad)](https://boards.greenhouse.io/alchemy/jobs/4330447005) | - | 10/21/2023 |
-| [Immuta](https://jobs.lever.co/immuta) | - College Park, MD | ✅ [Software Engineer, Application Support](https://jobs.lever.co/immuta/1bf0d39c-a5a3-4d4f-a625-80945fad56c1/apply) | - | 10/21/2023 |
+| [Immuta](https://jobs.lever.co/immuta) | - College Park, MD | ✅ [Software Engineer, Application Support](https://jobs.lever.co/immuta/1bf0d39c-a5a3-4d4f-a625-80945fad56c1/apply) | At this time, Immuta is unable to sponsor a new applicant for employment authorization now or in the future for this position. | 10/21/2023 |
 | [Forward](https://goforward.com/jobs) | - San Francisco, CA| ✅ [Software Engineer, Full Stack (Entry Level)](https://jobs.lever.co/goforward/073d1961-b3fd-4515-a7a4-a34a2eedb74a/apply) | - | 10/21/2023 |
 | [Qumulo](https://qumulo.com/careers/) | - Seattle, WA | ✅ [Software Development Engineer: Entry-Level, 2024](https://boards.greenhouse.io/qumulo/jobs/5427091) | - | 10/20/2023 |
 | [Relx](https://relx.wd3.myworkdayjobs.com/relx) | - Alpharetta, GA | 🔒 [Software Engineer I](https://relx.wd3.myworkdayjobs.com/en-US/relx/job/Alpharetta-GA/Software-Engineer-I_R64836-2/) | - | 10/19/2023 |


### PR DESCRIPTION
Citizenship/Visa Requirements were missing for Software Engineer, Application Support position @ Immuta.